### PR TITLE
SRVKP-1479: R&D Get a pipeline running with kata containers

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: pipelines-vote-ui
     spec:
+      runtimeClassName: kata
       containers:
         - image: quay.io/openshift-pipeline/vote-ui:latest
           imagePullPolicy: Always


### PR DESCRIPTION
This change makes it possible to use kata as the default container runtime.
Goes along with https://github.com/openshift-pipelines/pipelines-tutorial/pull/1